### PR TITLE
Multiple replaces in environment variables

### DIFF
--- a/config/frontier.php
+++ b/config/frontier.php
@@ -33,6 +33,9 @@ return [
 
         'cache' => env('FRONTIER_CACHE', true),
 
+        'headers' => [
+            'Accept' => 'text/html',
+        ],
     ],
 
 ];

--- a/config/frontier.php
+++ b/config/frontier.php
@@ -26,9 +26,10 @@ return [
         // https://laravel.com/docs/middleware
         'middleware' => [],
 
-        'replaces' => [
-            env('FRONTIER_FIND') => env('FRONTIER_REPLACE_WITH'),
-        ],
+        'replaces' => array_combine(
+            explode(',', env('FRONTIER_FIND')),
+            explode(',', env('FRONTIER_REPLACE_WITH')),
+        ),
 
         'cache' => env('FRONTIER_CACHE', true),
 


### PR DESCRIPTION
Allow that multiple replaces will be set in `.env` files to don't dirty `frontier.php` config file.

Exemplo for Vue.js user:

```bash
FRONTIER_ENDPOINT=/vue
FRONTIER_TYPE=http
FRONTIER_VIEW=https://localhost:5173/
FRONTIER_FIND=/@vite/client,/src/main.ts
FRONTIER_REPLACE_WITH=https://localhost:5173/@vite/client,https://localhost:5173/src/main.ts
FRONTIER_CACHE=false
```

For Vue.js application works correcly, HTTP Accept header is required to get the correct HTML content.