### PR TITLE
Add proxy strategy 

### DIFF
--- a/config/frontier.php
+++ b/config/frontier.php
@@ -31,6 +31,8 @@ return [
             explode(',', env('FRONTIER_REPLACE_WITH')),
         ),
 
+        'proxy' => explode(',', env('FRONTIER_PROXY')),
+
         'cache' => env('FRONTIER_CACHE', true),
 
         'headers' => [

--- a/src/FrontendProxyController.php
+++ b/src/FrontendProxyController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Dex\Laravel\Frontier;
+
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Http;
+
+class FrontendProxyController
+{
+    public function __invoke($uri, $config): Response
+    {
+        $url = trim($config['view'], '/') . '/' . trim($uri, '/');
+
+        $response = Http::get($url);
+
+        $content = $response->body();
+        $contextType = $response->header('content-type');
+
+        return new Response($content, headers: [
+            'content-type' => $contextType,
+        ]);
+    }
+}

--- a/src/FrontierServiceProvider.php
+++ b/src/FrontierServiceProvider.php
@@ -34,12 +34,21 @@ class FrontierServiceProvider extends ServiceProvider
                 'uri' => '',
                 'config' => $config,
             ]);
+
+        foreach ($config['proxy'] ?? [] as $uri) {
+            Route::get($uri, $this->getControllerFromType('proxy'))
+                ->setDefaults([
+                    'uri' => $uri,
+                    'config' => $config,
+                ]);
+        }
     }
 
     private function getControllerFromType(string $type): string
     {
         return match ($type) {
             'http' => FrontendHttpController::class,
+            'proxy' => FrontendProxyController::class,
             'view' => FrontendViewController::class,
             default => throw new InvalidArgumentException('Unknown controller type'),
         };

--- a/tests/FrontendProxyControllerTest.php
+++ b/tests/FrontendProxyControllerTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Dex\Laravel\Frontier\Tests;
+
+use Illuminate\Support\Facades\Http;
+
+class FrontendProxyControllerTest extends TestCase
+{
+    public function testProxyController(): void
+    {
+        $text = 'Frontier by Proxy';
+
+        Http::fake([
+            'localhost/proxy-uri' => Http::response($text),
+        ]);
+
+        $this->get('/proxy-uri')
+            ->assertStatus(200)
+            ->assertSeeText($text);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,6 +23,9 @@ abstract class TestCase extends OrchestraTestCase
                     'endpoint' => 'http',
                     'view' => 'http://localhost',
                     'cache' => false,
+                    'proxy' => [
+                        'proxy-uri'
+                    ],
                 ],
                 'http-with-cache' => [
                     'type' => 'http',


### PR DESCRIPTION
Adds a proxy strategy  to the asset server, to redirect files that could not be rewritten by Frontier or frontend framework.