### PR TITLE
Environment variables not informed

### DIFF
--- a/config/frontier.php
+++ b/config/frontier.php
@@ -27,8 +27,8 @@ return [
         'middleware' => [],
 
         'replaces' => array_combine(
-            explode(',', env('FRONTIER_FIND')),
-            explode(',', env('FRONTIER_REPLACE_WITH')),
+            array_filter(explode(',', env('FRONTIER_FIND'))),
+            array_filter(explode(',', env('FRONTIER_REPLACE_WITH'))),
         ),
 
         'proxy' => array_filter(explode(',', env('FRONTIER_PROXY'))),

--- a/config/frontier.php
+++ b/config/frontier.php
@@ -31,7 +31,7 @@ return [
             explode(',', env('FRONTIER_REPLACE_WITH')),
         ),
 
-        'proxy' => explode(',', env('FRONTIER_PROXY')),
+        'proxy' => array_filter(explode(',', env('FRONTIER_PROXY'))),
 
         'cache' => env('FRONTIER_CACHE', true),
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,1 +1,4 @@
 <?php
+
+uses(Dex\Laravel\Frontier\Tests\TestCase::class)
+    ->in('Unit');

--- a/tests/Unit/DefaultConfigurationTest.php
+++ b/tests/Unit/DefaultConfigurationTest.php
@@ -1,18 +1,18 @@
 <?php
 
-test('when FRONTIER_PROXY is not informed `proxy` key should be empty', function () {
+test('when `FRONTIER_PROXY` is not informed `proxy` key should be empty', function () {
     $config = config('frontier.frontier.proxy');
 
     expect($config)->toBeEmpty();
 });
 
-test('when FRONTIER_FIND is not informed `replaces` key should be empty', function () {
+test('when `FRONTIER_FIND` is not informed `replaces` key should be empty', function () {
     $config = config('frontier.frontier.replaces');
 
     expect($config)->toBeEmpty();
 });
 
-test('when FRONTIER_REPLACE_WITH is not informed `replaces` key should be empty', function () {
+test('when `FRONTIER_REPLACE_WITH` is not informed `replaces` key should be empty', function () {
     $config = config('frontier.frontier.replaces');
 
     expect($config)->toBeEmpty();

--- a/tests/Unit/DefaultConfigurationTest.php
+++ b/tests/Unit/DefaultConfigurationTest.php
@@ -1,0 +1,7 @@
+<?php
+
+test('when FRONTIER_PROXY is not informed `proxy` key should be empty', function () {
+    $config = config('frontier.frontier.proxy');
+
+    expect($config)->toBeEmpty();
+});

--- a/tests/Unit/DefaultConfigurationTest.php
+++ b/tests/Unit/DefaultConfigurationTest.php
@@ -5,3 +5,15 @@ test('when FRONTIER_PROXY is not informed `proxy` key should be empty', function
 
     expect($config)->toBeEmpty();
 });
+
+test('when FRONTIER_FIND is not informed `replaces` key should be empty', function () {
+    $config = config('frontier.frontier.replaces');
+
+    expect($config)->toBeEmpty();
+});
+
+test('when FRONTIER_REPLACE_WITH is not informed `replaces` key should be empty', function () {
+    $config = config('frontier.frontier.replaces');
+
+    expect($config)->toBeEmpty();
+});


### PR DESCRIPTION
When environment variables are not informed, dirty values are living in default `frontier` configuration.