### PR TITLE
Change string separator

### DIFF
--- a/config/frontier.php
+++ b/config/frontier.php
@@ -46,7 +46,7 @@ return [
 
         'host' => env('FRONTIER_PROXY_HOST', ''),
 
-        'rules' => array_filter(explode(',', env('FRONTIER_PROXY_RULES', ''))),
+        'rules' => array_filter(explode('|', env('FRONTIER_PROXY_RULES', ''))),
 
     ],
 

--- a/src/Frontier.php
+++ b/src/Frontier.php
@@ -34,7 +34,7 @@ class Frontier
         $rules = $config['rules'] ?? [];
 
         foreach ($rules as $rule) {
-            $segments = explode(':', $rule);
+            $segments = explode('::', $rule);
 
             $url = $host;
             $uri = $segments[0];

--- a/tests/FrontendProxyControllerTest.php
+++ b/tests/FrontendProxyControllerTest.php
@@ -11,9 +11,9 @@ beforeEach(fn () => Frontier::add([
     'type' => 'proxy',
     'host' => 'frontier.test',
     'rules' => [
-        '/favicon.ico:exact',
-        '/exact/replace:exact:replace(/exact/replace)',
-        '/all:replace(Replace,is amazing!)',
+        '/favicon.ico::exact',
+        '/exact/replace::exact::replace(/exact/replace,https://frontier.test/another/exact/replace)',
+        '/all::replace(Replace,is amazing!)',
         '/web',
     ],
 ]));
@@ -55,7 +55,7 @@ test('proxy exact and replace', function () {
     ]);
 
     $this->get('/exact/replace')
-        ->assertContent('Running: frontier.test/exact/replace')
+        ->assertContent('Running: https://frontier.test/another/exact/replace')
         ->assertOk();
 
     $this->get('exact/replace/more')


### PR DESCRIPTION
`:` and `,` are used often in URLs and as well string separator 