### PR TITLE
Avoid empty configuration

### DIFF
--- a/src/Frontier.php
+++ b/src/Frontier.php
@@ -11,6 +11,10 @@ class Frontier
 {
     public static function add(array $config): void
     {
+        if (empty($config['type'])) {
+            return;
+        }
+
         match ($config['type']) {
             'http' => self::http($config),
             'proxy' => self::proxy($config),


### PR DESCRIPTION
When `frontier.php` config file is overwritten, an error is thrown.