### PR TITLE
Allow enable or disable Frontier

### DIFF
--- a/config/frontier.php
+++ b/config/frontier.php
@@ -6,6 +6,8 @@ return [
 
     'frontier' => [
 
+        'enabled' => env('FRONTIER_DEFAULT_ENABLED', true),
+
         'type' => env('FRONTIER_TYPE', 'view'),
 
         'endpoint' => env('FRONTIER_ENDPOINT', 'frontier'),
@@ -46,6 +48,8 @@ return [
     ],
 
     'proxy' => [
+
+        'enabled' => env('FRONTIER_PROXY_ENABLED', true),
 
         'type' => 'proxy',
 

--- a/src/Frontier.php
+++ b/src/Frontier.php
@@ -11,10 +11,6 @@ class Frontier
 {
     public static function add(array $config): void
     {
-        if (empty($config['type'])) {
-            return;
-        }
-
         match ($config['type']) {
             'http' => self::http($config),
             'proxy' => self::proxy($config),

--- a/tests/FrontendHttpControllerTest.php
+++ b/tests/FrontendHttpControllerTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Http;
 
 test('`http` controller', function () {
     Frontier::add([
+        'enabled' => true,
         'type' => 'http',
         'endpoint' => 'http',
         'view' => 'http://frontier.test',
@@ -16,6 +17,7 @@ test('`http` controller', function () {
     ]);
 
     Frontier::add([
+        'enabled' => true,
         'type' => 'http',
         'endpoint' => 'http-with-cache',
         'view' => 'http://frontier.test',

--- a/tests/FrontendProxyControllerTest.php
+++ b/tests/FrontendProxyControllerTest.php
@@ -8,6 +8,7 @@ use Dex\Laravel\Frontier\Frontier;
 use Illuminate\Support\Facades\Http;
 
 beforeEach(fn () => Frontier::add([
+    'enabled' => true,
     'type' => 'proxy',
     'host' => 'frontier.test',
     'rules' => [

--- a/tests/FrontendViewControllerTest.php
+++ b/tests/FrontendViewControllerTest.php
@@ -8,6 +8,7 @@ use Dex\Laravel\Frontier\Frontier;
 
 test('`view` controller', function () {
     Frontier::add([
+        'enabled' => true,
         'type' => 'view',
         'endpoint' => 'view',
         'view' => 'frontier::index',


### PR DESCRIPTION
Use `FRONTIER_DEFAULT_ENABLED` to enable/disable default (http, view) routes.

Use `FRONTIER_PROXY_ENABLED` to enable/disable default proxy routes.